### PR TITLE
Transparent sorting

### DIFF
--- a/source/CompiledImage.cs
+++ b/source/CompiledImage.cs
@@ -1,5 +1,4 @@
-﻿using Materials;
-using Materials.Components;
+﻿using Materials.Components;
 using System;
 using Vulkan;
 
@@ -7,17 +6,17 @@ namespace Rendering.Vulkan
 {
     public readonly struct CompiledImage : IDisposable
     {
-        public readonly Material material;
-        public readonly uint textureVersion;
+        public readonly uint materialEntity;
+        public readonly ushort textureVersion;
         public readonly TextureBinding binding;
         public readonly Image image;
         public readonly ImageView imageView;
         public readonly DeviceMemory imageMemory;
         public readonly Sampler sampler;
 
-        public CompiledImage(Material material, uint textureVersion, TextureBinding binding, Image image, ImageView imageView, DeviceMemory imageMemory, Sampler sampler)
+        public CompiledImage(uint materialEntity, ushort textureVersion, TextureBinding binding, Image image, ImageView imageView, DeviceMemory imageMemory, Sampler sampler)
         {
-            this.material = material;
+            this.materialEntity = materialEntity;
             this.textureVersion = textureVersion;
             this.binding = binding;
             this.image = image;

--- a/source/CompiledShader.cs
+++ b/source/CompiledShader.cs
@@ -6,12 +6,12 @@ namespace Rendering.Vulkan
     public readonly struct CompiledShader : IDisposable, IEquatable<CompiledShader>
     {
         public readonly bool isInstanced;
-        public readonly uint vertexVersion;
-        public readonly uint fragmentVersion;
+        public readonly ushort vertexVersion;
+        public readonly ushort fragmentVersion;
         public readonly ShaderModule vertexShader;
         public readonly ShaderModule fragmentShader;
 
-        public CompiledShader(uint vertexVersion, uint fragmentVersion, ShaderModule vertexShader, ShaderModule fragmentShader, bool isInstanced)
+        public CompiledShader(ushort vertexVersion, ushort fragmentVersion, ShaderModule vertexShader, ShaderModule fragmentShader, bool isInstanced)
         {
             this.isInstanced = isInstanced;
             this.vertexVersion = vertexVersion;

--- a/source/Extensions/TypeLayoutExtensions.cs
+++ b/source/Extensions/TypeLayoutExtensions.cs
@@ -1,12 +1,13 @@
 ﻿using System;
 using System.Numerics;
+using Types;
 using Vortice.Vulkan;
 
 namespace Rendering.Vulkan
 {
     public static class TypeLayoutExtensions
     {
-        public static VkFormat GetFormat(this Types.Type type)
+        public static VkFormat GetFormat(this TypeMetadata type)
         {
             if (type.Is<Vector2>())
             {

--- a/source/Objects/VertexInputAttribute.cs
+++ b/source/Objects/VertexInputAttribute.cs
@@ -24,20 +24,20 @@ namespace Vulkan
             this.size = size;
         }
 
-        public VertexInputAttribute(byte location, byte binding, Type type, byte size)
+        public VertexInputAttribute(byte location, byte binding, TypeMetadata type)
         {
             this.location = location;
             this.binding = binding;
             this.format = type.GetFormat();
-            this.size = size;
+            this.size = (byte)type.Size;
         }
 
         public VertexInputAttribute(ShaderVertexInputAttribute shaderVertexAttribute)
         {
             location = shaderVertexAttribute.location;
             binding = shaderVertexAttribute.binding;
-            format = shaderVertexAttribute.Type.GetFormat();
-            size = shaderVertexAttribute.size;
+            format = shaderVertexAttribute.type.GetFormat();
+            size = (byte)shaderVertexAttribute.type.Size;
         }
     }
 }

--- a/source/RendererKey.cs
+++ b/source/RendererKey.cs
@@ -1,0 +1,44 @@
+﻿using System;
+
+namespace Rendering.Vulkan
+{
+    public readonly struct RendererKey : IEquatable<RendererKey>
+    {
+        public readonly ulong value;
+
+        public RendererKey(uint materialEntity, uint meshEntity)
+        {
+            value = ((ulong)materialEntity << 32) | meshEntity;
+        }
+
+        public readonly override string ToString()
+        {
+            return value.ToString();
+        }
+
+        public readonly bool Equals(RendererKey other)
+        {
+            return value == other.value;
+        }
+
+        public override readonly bool Equals(object? obj)
+        {
+            return obj is RendererKey key && Equals(key);
+        }
+
+        public readonly override int GetHashCode()
+        {
+            return value.GetHashCode();
+        }
+
+        public static bool operator ==(RendererKey left, RendererKey right)
+        {
+            return left.Equals(right);
+        }
+
+        public static bool operator !=(RendererKey left, RendererKey right)
+        {
+            return !left.Equals(right);
+        }
+    }
+}

--- a/source/VulkanBackend.cs
+++ b/source/VulkanBackend.cs
@@ -22,41 +22,42 @@ namespace Rendering.Vulkan
             library = new();
         }
 
-        (MemoryAddress renderer, MemoryAddress instance) IRenderingBackend.Create(in Destination destination, in ReadOnlySpan<DestinationExtension> extensionNames)
+        (MemoryAddress machine, MemoryAddress instance) IRenderingBackend.Create(in Destination destination, in ReadOnlySpan<DestinationExtension> extensionNames)
         {
             Instance instance = library.CreateInstance("Game", "Engine", extensionNames);
-            VulkanRenderer renderer = new(destination, instance);
-            return (MemoryAddress.AllocateValue(renderer), renderer.Instance);
+            VulkanRenderer machine = new(destination, instance);
+            MemoryAddress instanceAddress = new(instance.Value.Handle);
+            return (MemoryAddress.AllocateValue(machine), instanceAddress);
         }
 
-        void IRenderingBackend.Dispose(in MemoryAddress renderer)
+        void IRenderingBackend.Dispose(in MemoryAddress machine, in MemoryAddress instance)
         {
-            ref VulkanRenderer vulkanRenderer = ref renderer.Read<VulkanRenderer>();
+            ref VulkanRenderer vulkanRenderer = ref machine.Read<VulkanRenderer>();
             vulkanRenderer.Dispose();
-            renderer.Dispose();
+            machine.Dispose();
         }
 
-        void IRenderingBackend.SurfaceCreated(in MemoryAddress renderer, MemoryAddress surface)
+        void IRenderingBackend.SurfaceCreated(in MemoryAddress machine, MemoryAddress surface)
         {
-            ref VulkanRenderer vulkanRenderer = ref renderer.Read<VulkanRenderer>();
+            ref VulkanRenderer vulkanRenderer = ref machine.Read<VulkanRenderer>();
             vulkanRenderer.SurfaceCreated(surface);
         }
 
-        StatusCode IRenderingBackend.BeginRender(in MemoryAddress renderer, in Vector4 clearColor)
+        StatusCode IRenderingBackend.BeginRender(in MemoryAddress machine, in Vector4 clearColor)
         {
-            ref VulkanRenderer vulkanRenderer = ref renderer.Read<VulkanRenderer>();
+            ref VulkanRenderer vulkanRenderer = ref machine.Read<VulkanRenderer>();
             return vulkanRenderer.BeginRender(clearColor);
         }
 
-        void IRenderingBackend.Render(in MemoryAddress renderer, in ReadOnlySpan<uint> entities, in MaterialData material, in MeshData mesh, in VertexShaderData vertexShader, in FragmentShaderData fragmentShader)
+        void IRenderingBackend.Render(in MemoryAddress machine, in uint materialEntity, in ushort materialVersion, in ReadOnlySpan<RenderEntity> entities)
         {
-            ref VulkanRenderer vulkanRenderer = ref renderer.Read<VulkanRenderer>();
-            vulkanRenderer.Render(entities, material, mesh, vertexShader, fragmentShader);
+            ref VulkanRenderer vulkanRenderer = ref machine.Read<VulkanRenderer>();
+            vulkanRenderer.Render(materialEntity, materialVersion, entities);
         }
 
-        void IRenderingBackend.EndRender(in MemoryAddress renderer)
+        void IRenderingBackend.EndRender(in MemoryAddress machine)
         {
-            ref VulkanRenderer vulkanRenderer = ref renderer.Read<VulkanRenderer>();
+            ref VulkanRenderer vulkanRenderer = ref machine.Read<VulkanRenderer>();
             vulkanRenderer.EndRender();
         }
     }

--- a/source/VulkanBackend.cs
+++ b/source/VulkanBackend.cs
@@ -49,10 +49,10 @@ namespace Rendering.Vulkan
             return vulkanRenderer.BeginRender(clearColor);
         }
 
-        void IRenderingBackend.Render(in MemoryAddress machine, in uint materialEntity, in ushort materialVersion, in ReadOnlySpan<RenderEntity> entities)
+        void IRenderingBackend.Render(in MemoryAddress machine, in sbyte renderGroup, in ReadOnlySpan<RenderEntity> entities)
         {
             ref VulkanRenderer vulkanRenderer = ref machine.Read<VulkanRenderer>();
-            vulkanRenderer.Render(materialEntity, materialVersion, entities);
+            vulkanRenderer.Render(renderGroup, entities);
         }
 
         void IRenderingBackend.EndRender(in MemoryAddress machine)

--- a/source/VulkanRenderer.cs
+++ b/source/VulkanRenderer.cs
@@ -415,10 +415,10 @@ namespace Rendering.Vulkan
                 ref ShaderVertexInputAttribute shaderVertexAttribute = ref shaderVertexAttributes[i];
                 ref VkVertexInputAttributeDescription vulkanVertexAttribute = ref vertexAttributes[i];
                 vulkanVertexAttribute.location = shaderVertexAttribute.location;
-                vulkanVertexAttribute.format = shaderVertexAttribute.Type.GetFormat();
+                vulkanVertexAttribute.format = shaderVertexAttribute.type.GetFormat();
                 vulkanVertexAttribute.binding = shaderVertexAttribute.binding;
                 vulkanVertexAttribute.offset = offset;
-                offset += shaderVertexAttribute.size;
+                offset += shaderVertexAttribute.type.Size;
             }
 
             Material material = Entity.Get<Material>(world, materialEntity);


### PR DESCRIPTION
changes to the renderer machine to be up to date with rendering interfaces. makes it possible to render things in a more precise order at the cost of more time spent jumping from pipeline to pipeline.